### PR TITLE
Apply policy for @atomist/automation-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/automation-client": "1.3.0-master.20190206192652",
+    "@atomist/automation-client": "^1.6.2",
     "@atomist/automation-client-ext-dashboard": "1.0.2-master.20190122114232",
     "@atomist/automation-client-ext-logzio": "1.0.2-master.20190111233251",
     "@atomist/sdm": "https://registry.npmjs.org/@atomist/sdm/-/@atomist/sdm-1.3.0-master.20190206205235.tgz",


### PR DESCRIPTION
Apply policy `npm-project-deps::atomist::automation-client`:

**New NPM Package Version Policy**
Policy version for NPM package *@atomist/automation-client* is `^1.6.2`.
Project *sdm-org/bigmac/master* is currently using version `1.3.0-master.20190206192652`.

_NPM dependencies_
```@atomist/automation-client (^1.6.2)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::automation-client=87efccbdfd36903fd5d1f0d492c5f0d6a37287a0901717d24f21eaf7a75136fe]</code>
</details>